### PR TITLE
Preserve refresh token

### DIFF
--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -685,6 +685,9 @@ AWSCognito.CognitoIdentityServiceProvider.CognitoUser = (function() {
                 return callback(err, null);
             }
             if (authResult) {
+                if (!authResult.AuthenticationResult.hasOwnProperty('RefreshToken')) {
+                    authResult.AuthenticationResult.RefreshToken = refreshToken.getToken();
+                }
                 self.signInUserSession = self.getCognitoUserSession(authResult.AuthenticationResult);
                 self.cacheTokens();
                 return callback(null, self.signInUserSession);


### PR DESCRIPTION
When refreshing the session, hang onto the old refresh token if the
authentication result doesn’t provide a new one.  Without this change,
the refresh token is lost.
