### PR TITLE
Fix ESLint issues from restoring deviceStuff.

### DIFF
--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -232,7 +232,7 @@ export default class CognitoUser {
           return callback.onSuccess(this.signInUserSession);
         }
 
-        const deviceStuff = authenticationHelper.generateHashDevice(
+        authenticationHelper.generateHashDevice(
            dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceGroupKey,
            dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey);
 
@@ -447,9 +447,9 @@ export default class CognitoUser {
       const authenticationHelper = new AuthenticationHelper(
         this.pool.getUserPoolId().split('_')[1],
         this.pool.getParanoia());
-        const deviceStuff = authenticationHelper.generateHashDevice(
-          dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceGroupKey,
-          dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey);
+      authenticationHelper.generateHashDevice(
+        dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceGroupKey,
+        dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey);
 
       const deviceSecretVerifierConfig = {
         Salt: sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(


### PR DESCRIPTION
Whoops! `AuthenticationHelper.generateHashDevice()` was called for
side-effects, and doesn't return to boot.

This fixes the eslint errors when @itrestian restored those lines.
