### PR TITLE
Fix root (<script>) jsbn external reference to match existing usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^1.13.1"
   },
   "scripts": {
-    "build": "webpack",
+    "build": "webpack -p",
     "doc": "jsdoc src -d docs",
     "lint": "eslint src"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,16 +28,22 @@ module.exports = {
   },
   devtool: 'source-map',
   externals: {
-    // Not in documentation, see: thttps://github.com/webpack/webpack/tree/master/examples/externals
+    // This umd context config isn't in configuration documentation, but see example:
+    // https://github.com/webpack/webpack/tree/master/examples/externals
     'aws-sdk': {
       root: 'AWSCognito',
-      commonjs2: 'aws-sdk',
-      commonjs: 'aws-sdk',
-      amd: 'aws-sdk'
+      commonjs2: true,
+      commonjs: true,
+      amd: true
     },
     // Exclude 3rd-party code from the bundle.
     sjcl: true,
-    jsbn: true
+    jsbn: {
+      root: 'window', // non-npm jsbn exports to global
+      commonjs2: true,
+      commonjs: true,
+      amd: true
+    }
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
I broke existing usage in #108, the docs reference the jsbn scripts at http://www-cs-students.stanford.edu/%7Etjw/jsbn/ which just dumps all their definitions to global scope, while the npm jsbn package wraps them in `jsbn`, even in `<script>`/concat usage.

Also make the externals comment more useful, and set the production flag for `npm run buld` (though it has no real effect).

While testing, I noticed the `sjcl.js` linked on the project homepage doesn't work due to `sjcl.misc.hmac` not having `update`: the github file works fine though.
