### PR TITLE
Always get service region from UserPoolId prefix.

### DIFF
--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -17,7 +17,6 @@
 
 import * as sjcl from 'sjcl';
 import { BigInteger } from 'jsbn';
-import { CognitoIdentityServiceProvider } from 'aws-sdk';
 
 import AuthenticationHelper from './AuthenticationHelper';
 import CognitoAccessToken from './CognitoAccessToken';
@@ -84,7 +83,7 @@ export default class CognitoUser {
     this.pool = data.Pool;
     this.Session = null;
 
-    this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19' });
+    this.client = data.Pool.client;
 
     this.signInUserSession = null;
     this.authenticationFlowType = 'USER_SRP_AUTH';

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -29,15 +29,20 @@ export default class CognitoUserPool {
    * @param {int=} data.Paranoia Random number generation paranoia level.
    */
   constructor(data) {
-    if (data == null || data.UserPoolId == null || data.ClientId == null) {
-      throw new Error('Both user pool Id and client Id are required.');
+    const { UserPoolId, ClientId, Paranoia } = data || {};
+    if (!UserPoolId || !ClientId) {
+      throw new Error('Both UserPoolId and ClientId are required.');
     }
+    if (!/^[\w-]+_.+$/.test(UserPoolId)) {
+      throw new Error('Invalid UserPoolId format.');
+    }
+    const region = UserPoolId.split('_')[0];
 
-    this.userPoolId = data.UserPoolId;
-    this.clientId = data.ClientId;
-    this.paranoia = data.Paranoia || 0;
+    this.userPoolId = UserPoolId;
+    this.clientId = ClientId;
+    this.paranoia = Paranoia || 0;
 
-    this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19' });
+    this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19', region });
   }
 
   /**


### PR DESCRIPTION
Removes the need to configure `AWSCognito.config.region`.

I'm not sure that you guys are OK with committing to UserPoolId always starting with the service region, but it seems likely. Otherwise, optionally accepting region or the client instance in the `CognitoUserPool` constructor would make things a bit nicer.
