### PR TITLE
Fixed Use case 6 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Note that if device tracking is enabled for the user pool with a setting that us
         onFailure: function(err) {
             alert(err);
         },
-        inputVerificationCode() {
+        inputVerificationCode: function() {
             var verificationCode = prompt('Please input verification code: ' ,'');
             cognitoUser.verifyAttribute('email', verificationCode, this);
         }


### PR DESCRIPTION
I used a code described in `Use case 6` on README, but it did not work due to an error saying `SyntaxError: missing: after property id this.inputVerificationCode = function () {I used the code . But`.

I modified the README because `: function` is missing in inputVerificationCode.
