### PR TITLE
Remove the CognitoIdentityServiceProvider declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
 declare module "amazon-cognito-identity-js" {
 
-    import { ClientConfig } from "aws-sdk";
-
     export interface IAuthenticationDetailsData {
         Username: string;
         Password: string;
@@ -87,10 +85,6 @@ declare module "amazon-cognito-identity-js" {
         public getRefreshToken(): CognitoRefreshToken;
         public getAccessToken(): CognitoAccessToken;
         public isValid(): boolean;
-    }
-
-    export class CognitoIdentityServiceProvider {
-        public config: ClientConfig;
     }
 
     export class CognitoAccessToken {


### PR DESCRIPTION
There doesn't seem to be a `ClientConfig` exported by the aws-sdk anymore. I think that for the Cognito identity service provider this has been replaced by [`CognitoIdentityServiceProvider.Types.ClientConfiguration`](https://github.com/aws/aws-sdk-js/blob/master/clients/cognitoidentityserviceprovider.d.ts#L12). This results in a compilation error for anything importing `amazon-cognito-identity-js`.

Furthermore aws-sdk now exports the `CognitoIdentityServiceProvider` type which means we don't need to re-declare it here.