### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,9 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
         Name : 'phone_number',
         Value : '+15555555555'
     };
-    var attributeEmail = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(dataEmail);
-    var attributePhoneNumber = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(dataPhoneNumber);
 
-    attributeList.push(attributeEmail);
-    attributeList.push(attributePhoneNumber);
+    attributeList.push(dataEmail);
+    attributeList.push(dataPhoneNumber);
 
     userPool.signUp('username', 'password', attributeList, null, function(err, result){
         if (err) {


### PR DESCRIPTION
In Registering a User,

Plain object for dataEmail is working fine.
attributeList.push(dataEmail);

and it's an error if we pass dataEmail as CognitoUserAttribute:
new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(dataEmail);