### PR TITLE
Replace sjcl with corresponding methods from aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ The Amazon Cognito Identity SDK for JavaScript depends on:
 
 2. `BigInteger` from the [JavaScript BN library](http://www-cs-students.stanford.edu/~tjw/jsbn/) developed by Tom Wu, the inventor of the Secure Remote Password protocol. This implementation uses Montgomery multiplication to rapidly perform the computations needed by the Secure Remote Password protocol.
 
-3. The [Stanford JavaScript Crypto Library](https://github.com/bitwiseshiftleft/sjcl)
-
 There are two ways to install the Amazon Cognito Identity SDK for JavaScript and its dependencies,
 depending on your project setup and experience with modern JavaScript build tools:
 
@@ -55,11 +53,6 @@ project:
 
 4. `jsbn.js` and `jsbn2.js` from the [JavaScript BN library](http://www-cs-students.stanford.edu/~tjw/jsbn/) developed by Tom Wu, the inventor of the Secure Remote Password protocol.
 
-5. `sjcl.js` from the [Stanford JavaScript Crypto Library](https://github.com/bitwiseshiftleft/sjcl)
-
-   Use the build from GitHub, rather than the one linked from the library's homepage, as the latter
-   file is out-of-date and is missing required methods. [This version](https://raw.githubusercontent.com/bitwiseshiftleft/sjcl/master/sjcl.js) contains all the necessary functions.
-
 Optionally, to use other AWS services, include a build of the [AWS SDK for JavaScript](http://aws.amazon.com/sdk-for-browser/).
 
 Include all of the files in your HTML page before calling any Amazon Cognito Identity SDK APIs:
@@ -67,9 +60,9 @@ Include all of the files in your HTML page before calling any Amazon Cognito Ide
 ```html
     <script src="/path/to/jsbn.js"></script>
     <script src="/path/to/jsbn2.js"></script>
-    <script src="/path/to/sjcl.js"></script>
     <script src="/path/to/aws-cognito-sdk.min.js"></script>
     <script src="/path/to/amazon-cognito-identity.min.js"></script>
+    <!-- optional: only if you use other AWS services -->
     <script src="/path/to/aws-sdk-2.6.10.js"></script>
 ```
 
@@ -660,33 +653,7 @@ For most frameworks you can whitelist the domain by whitelisting all AWS endpoin
 
 ## Random numbers
 
-In order to authenticate with the Amazon Cognito Identity Service, the client needs to generate a random number as part of the SRP protocol. Note that in some web browsers such as Internet Explorer 8, Internet Explorer 9, or versions 4.2 and 4.3 of the Android Browser, a default paranoia of 0 passed to the Stanford Javascript Crypto Library generates weak random numbers that might compromise client data. Developers should be careful when using the library in such an environment and call the sjcl.random.startCollectors() function before starting the Cognito authentication flow in order to collect entropy required for random number generation. Paranoia level should also be increased.
-See discussion below:
-* https://github.com/bitwiseshiftleft/sjcl/issues/77
-
-Paranoia levels can be set through the constructor:
-
-```javascript
-    var poolData = {
-        UserPoolId : '...', // Your user pool id here
-        ClientId : '...', // Your client id here
-        Paranoia : 7
-    };
-
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
-    var userData = {
-        Username : 'username',
-        Pool : userPool
-    };
-
-    var cognitoUser = new AWSCognito.CognitoIdentityServiceProvider.CognitoUser(userData);
-```
-
-or by calling the object method:
-
-```javascript
-    userPool.setParanoia(7);
-```
+In order to authenticate with the Amazon Cognito Identity Service, the client needs to generate a random number as part of the SRP protocol. The AWS SDK is only compatible with modern browsers, and these include support for cryptographically strong random values. If you do need to support older browsers then you should be aware that this is less secure, and if possible include a strong polyfill for `window.crypto.getRandomValues()` before including this library.
 
 ## Change Log
 **v1.12.0:**

--- a/enhance.js
+++ b/enhance.js
@@ -1,4 +1,4 @@
-import CognitoIdentityServiceProvider from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import { CognitoIdentityServiceProvider } from 'aws-sdk';
 import * as enhancements from './src';
 
 export * from './src';
@@ -6,3 +6,10 @@ export * from './src';
 Object.keys(enhancements).forEach(key => {
   CognitoIdentityServiceProvider[key] = enhancements[key];
 });
+
+// The version of crypto-browserify included by aws-sdk only
+// checks for window.crypto, not window.msCrypto as used by
+// IE 11 – so we set it explicitly here
+if (typeof window !== 'undefined' && !window.crypto && window.msCrypto) {
+  window.crypto = window.msCrypto;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,6 @@ declare module "amazon-cognito-identity-js" {
     export interface ICognitoUserPool {
         UserPoolId: string;
         ClientId: string;
-        Paranoia?: number;
     }
 
     export class CognitoUserPool {
@@ -70,9 +69,6 @@ declare module "amazon-cognito-identity-js" {
 
         public getUserPoolId(): string;
         public getClientId(): string;
-        public getParanoia(): number
-
-        public setParanoia(paranoia: number): void;
 
         public signUp(username: string, password: string, userAttributes: any[], validationData: any[], callback: (err: any, result: any) => void): void;
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "aws-sdk": "^2.6.0",
-    "jsbn": "^0.1.0",
-    "sjcl": "^1.0.3"
+    "jsbn": "^0.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.13.2",

--- a/src/AuthenticationHelper.js
+++ b/src/AuthenticationHelper.js
@@ -183,8 +183,7 @@ export default class AuthenticationHelper {
    * @private
    */
   hexHash(hexStr) {
-    const hashHex = util.crypto.sha256(new util.Buffer(hexStr, 'hex'), 'hex');
-    return (new Array(64 - hashHex.length).join('0')) + hashHex;
+    return this.hash(new util.Buffer(hexStr, 'hex'));
   }
 
   /**

--- a/src/CognitoAccessToken.js
+++ b/src/CognitoAccessToken.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as sjcl from 'sjcl';
+import { util } from 'aws-sdk';
 
 /** @class */
 export default class CognitoAccessToken {
@@ -40,8 +40,7 @@ export default class CognitoAccessToken {
    */
   getExpiration() {
     const payload = this.jwtToken.split('.')[1];
-    const expiration = JSON.parse(
-      sjcl.codec.utf8String.fromBits(sjcl.codec.base64url.toBits(payload)));
+    const expiration = JSON.parse(util.base64.decode(payload).toString('utf8'));
     return expiration.exp;
   }
 }

--- a/src/CognitoIdToken.js
+++ b/src/CognitoIdToken.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as sjcl from 'sjcl';
+import { util } from 'aws-sdk';
 
 /** @class */
 export default class CognitoIdToken {
@@ -40,8 +40,7 @@ export default class CognitoIdToken {
    */
   getExpiration() {
     const payload = this.jwtToken.split('.')[1];
-    const expiration = JSON.parse(
-      sjcl.codec.utf8String.fromBits(sjcl.codec.base64url.toBits(payload)));
+    const expiration = JSON.parse(util.base64.decode(payload).toString('utf8'));
     return expiration.exp;
   }
 }

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as sjcl from 'sjcl';
+import { util } from 'aws-sdk';
 import { BigInteger } from 'jsbn';
 
 import AuthenticationHelper from './AuthenticationHelper';
@@ -137,8 +137,7 @@ export default class CognitoUser {
    */
   authenticateUser(authDetails, callback) {
     const authenticationHelper = new AuthenticationHelper(
-      this.pool.getUserPoolId().split('_')[1],
-      this.pool.getParanoia());
+      this.pool.getUserPoolId().split('_')[1]);
     const dateHelper = new DateHelper();
 
     let serverBValue;
@@ -178,16 +177,15 @@ export default class CognitoUser {
         authDetails.getPassword(),
         serverBValue,
         salt);
-      const secretBlockBits = sjcl.codec.base64.toBits(challengeParameters.SECRET_BLOCK);
 
-      const mac = new sjcl.misc.hmac(hkdf, sjcl.hash.sha256);
-      mac.update(sjcl.codec.utf8String.toBits(this.pool.getUserPoolId().split('_')[1]));
-      mac.update(sjcl.codec.utf8String.toBits(this.username));
-      mac.update(secretBlockBits);
       const dateNow = dateHelper.getNowString();
-      mac.update(sjcl.codec.utf8String.toBits(dateNow));
-      const signature = mac.digest();
-      const signatureString = sjcl.codec.base64.fromBits(signature);
+
+      const signatureString = util.crypto.hmac(hkdf, util.buffer.concat([
+        new util.Buffer(this.pool.getUserPoolId().split('_')[1], 'utf8'),
+        new util.Buffer(this.username, 'utf8'),
+        new util.Buffer(challengeParameters.SECRET_BLOCK, 'base64'),
+        new util.Buffer(dateNow, 'utf8')
+      ]), 'base64', 'sha256')
 
       const challengeResponses = {};
 
@@ -294,14 +292,11 @@ export default class CognitoUser {
       dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey);
 
     const deviceSecretVerifierConfig = {
-      Salt: sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(
-              authenticationHelper.getSaltDevices().toString(16))),
-      PasswordVerifier: sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(
-              authenticationHelper.getVerifierDevices().toString(16))),
+      Salt: new util.Buffer(authenticationHelper.getSaltDevices(), 'hex').toString('base64'),
+      PasswordVerifier: new util.Buffer(authenticationHelper.getVerifierDevices(), 'hex').toString('base64'),
     };
 
-    this.verifierDevices = sjcl.codec.base64.fromBits(
-      authenticationHelper.getVerifierDevices());
+    this.verifierDevices = deviceSecretVerifierConfig.PasswordVerifier;
     this.deviceGroupKey = newDeviceMetadata.DeviceGroupKey;
     this.randomPassword = authenticationHelper.getRandomPassword();
 
@@ -345,7 +340,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('New password is required.'));
     }
     const authenticationHelper = new AuthenticationHelper(
-      this.pool.getUserPoolId().split('_')[1], this.pool.getParanoia());
+      this.pool.getUserPoolId().split('_')[1]);
     const userAttributesPrefix = authenticationHelper
       .getNewPasswordRequiredChallengeUserAttributePrefix();
 
@@ -384,8 +379,7 @@ export default class CognitoUser {
    */
   getDeviceResponse(callback) {
     const authenticationHelper = new AuthenticationHelper(
-      this.deviceGroupKey,
-      this.pool.getParanoia());
+      this.deviceGroupKey);
     const dateHelper = new DateHelper();
 
     const authParameters = {};
@@ -413,16 +407,15 @@ export default class CognitoUser {
         this.randomPassword,
         serverBValue,
         salt);
-      const secretBlockBits = sjcl.codec.base64.toBits(challengeParameters.SECRET_BLOCK);
 
-      const mac = new sjcl.misc.hmac(hkdf, sjcl.hash.sha256);
-      mac.update(sjcl.codec.utf8String.toBits(this.deviceGroupKey));
-      mac.update(sjcl.codec.utf8String.toBits(this.deviceKey));
-      mac.update(secretBlockBits);
       const dateNow = dateHelper.getNowString();
-      mac.update(sjcl.codec.utf8String.toBits(dateNow));
-      const signature = mac.digest();
-      const signatureString = sjcl.codec.base64.fromBits(signature);
+
+      const signatureString = util.crypto.hmac(hkdf, util.buffer.concat([
+        new util.Buffer(this.deviceGroupKey, 'utf8'),
+        new util.Buffer(this.deviceKey, 'utf8'),
+        new util.Buffer(challengeParameters.SECRET_BLOCK, 'base64'),
+        new util.Buffer(dateNow, 'utf8')
+      ]), 'base64', 'sha256')
 
       const challengeResponses = {};
 
@@ -552,21 +545,17 @@ export default class CognitoUser {
       }
 
       const authenticationHelper = new AuthenticationHelper(
-        this.pool.getUserPoolId().split('_')[1],
-        this.pool.getParanoia());
+        this.pool.getUserPoolId().split('_')[1]);
       authenticationHelper.generateHashDevice(
         dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceGroupKey,
         dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey);
 
       const deviceSecretVerifierConfig = {
-        Salt: sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(
-          authenticationHelper.getSaltDevices().toString(16))),
-        PasswordVerifier: sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(
-          authenticationHelper.getVerifierDevices().toString(16))),
+        Salt: new util.Buffer(authenticationHelper.getSaltDevices(), 'hex').toString('base64'),
+        PasswordVerifier: new util.Buffer(authenticationHelper.getVerifierDevices(), 'hex').toString('base64'),
       };
 
-      this.verifierDevices = sjcl.codec.base64.fromBits(
-        authenticationHelper.getVerifierDevices());
+      this.verifierDevices = deviceSecretVerifierConfig.PasswordVerifier;
       this.deviceGroupKey = dataAuthenticate.AuthenticationResult
         .NewDeviceMetadata.DeviceGroupKey;
       this.randomPassword = authenticationHelper.getRandomPassword();

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import CognitoIdentityServiceProvider from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import { CognitoIdentityServiceProvider } from 'aws-sdk';
 
 import CognitoUser from './CognitoUser';
 import StorageHelper from './StorageHelper';
@@ -27,10 +27,9 @@ export default class CognitoUserPool {
    * @param {object} data Creation options.
    * @param {string} data.UserPoolId Cognito user pool id.
    * @param {string} data.ClientId User pool application client id.
-   * @param {int=} data.Paranoia Random number generation paranoia level.
    */
   constructor(data) {
-    const { UserPoolId, ClientId, Paranoia } = data || {};
+    const { UserPoolId, ClientId } = data || {};
     if (!UserPoolId || !ClientId) {
       throw new Error('Both UserPoolId and ClientId are required.');
     }
@@ -41,7 +40,6 @@ export default class CognitoUserPool {
 
     this.userPoolId = UserPoolId;
     this.clientId = ClientId;
-    this.paranoia = Paranoia || 0;
 
     this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19', region });
   }
@@ -58,22 +56,6 @@ export default class CognitoUserPool {
    */
   getClientId() {
     return this.clientId;
-  }
-
-  /**
-   * @returns {int} the paranoia level
-   */
-  getParanoia() {
-    return this.paranoia;
-  }
-
-  /**
-   * sets paranoia level
-   * @param {int} paranoia The new paranoia level.
-   * @returns {void}
-   */
-  setParanoia(paranoia) {
-    this.paranoia = paranoia;
   }
 
   /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,14 +30,13 @@ module.exports = {
   externals: {
     // This umd context config isn't in configuration documentation, but see example:
     // https://github.com/webpack/webpack/tree/master/examples/externals
-    'aws-sdk/clients/cognitoidentityserviceprovider': {
-      root: ['AWSCognito', 'CognitoIdentityServiceProvider'],
-      commonjs2: 'aws-sdk/clients/cognitoidentityserviceprovider',
-      commonjs: 'aws-sdk/clients/cognitoidentityserviceprovider',
-      amd: 'aws-sdk/clients/cognitoidentityserviceprovider'
+    'aws-sdk': {
+      root: ['AWSCognito'],
+      commonjs2: 'aws-sdk',
+      commonjs: 'aws-sdk',
+      amd: 'aws-sdk'
     },
     // Exclude 3rd-party code from the bundle.
-    sjcl: true,
     jsbn: {
       root: [], // non-npm jsbn exports to global
       commonjs2: 'jsbn',


### PR DESCRIPTION
Extracted only the sjcl removal (and cleanups / de-duplication) from #262

This PR removes the external sjcl dependency, replacing all references with corresponding methods from the `aws-sdk` which includes much of the needed functionality already (in `aws-cognito-sdk.min.js`)