### PR TITLE
Add RoleArn to update credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
 
             AWS.config.credentials = new AWS.CognitoIdentityCredentials({
                 IdentityPoolId : '...', // your identity pool id here
+		RoleArn: 'IDENTITY_POOL_AUTHNETICATED_ROLE_ARN',
                 Logins : {
                     // Change the key below according to the specific region your user pool is in.
                     'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>' : result.getIdToken().getJwtToken()
@@ -484,6 +485,7 @@ you can make inputVerificationCode call a no-op
 	    
             AWS.config.credentials = new AWS.CognitoIdentityCredentials({
                 IdentityPoolId : '...', // your identity pool id here
+		RoleArn: 'IDENTITY_POOL_AUTHNETICATED_ROLE_ARN',
                 Logins : {
                     // Change the key below according to the specific region your user pool is in.
                     'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>' : session.getIdToken().getJwtToken()
@@ -510,6 +512,7 @@ you can make inputVerificationCode call a no-op
                 // Add the User's Id Token to the Cognito credentials login map.
                 AWS.config.credentials = new AWS.CognitoIdentityCredentials({
                     IdentityPoolId: 'YOUR_IDENTITY_POOL_ID',
+		    RoleArn: 'IDENTITY_POOL_AUTHNETICATED_ROLE_ARN',
                     Logins: {
                         'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>': result.getIdToken().getJwtToken()
                     }


### PR DESCRIPTION
### What happened?
Without set `RoleArn`, if you follow the example on README.md, you must fail to update credentials. 

### Relative documents
1. http://stackoverflow.com/questions/30425942/aws-cognito-invalid-identity-pool-configuration#answer-33115793
2. https://aws.amazon.com/ko/blogs/developer/authentication-with-amazon-cognito-in-the-browser/