### PR TITLE
fix(type-definitions): fix incomplete type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module "amazon-cognito-identity-js" {
     export class CognitoUser {
         constructor(data: ICognitoUserData);
 
-        public getSignInUserSession(): CognitoUserSession;
+        public getSignInUserSession(): CognitoUserSession | null;
         public getUsername(): string;
 
         public getAuthenticationFlowType(): string;
@@ -102,7 +102,7 @@ declare module "amazon-cognito-identity-js" {
 
         public signUp(username: string, password: string, userAttributes: CognitoUserAttribute[], validationData: CognitoUserAttribute[], callback: NodeCallback<Error,ISignUpResult>): void;
 
-        public getCurrentUser(): CognitoUser;
+        public getCurrentUser(): CognitoUser | null;
     }
 
     export interface ICognitoUserSessionData {


### PR DESCRIPTION
Hello! Just a quick fix to slightly incorrect TypeScript typings

CognitoUser.getSignInUserSession() can return either CognitoUserSession or null
CognitoUserPool.getCurrentUser() can return either CognitoUser or null