### PR TITLE
[#87] Add configurable storage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,9 +17,17 @@ declare module "amazon-cognito-identity-js" {
         public getValidationData(): any[];
     }
 
+    export interface ICognitoStorage {
+        setItem(key: string, value: string): void;
+        getItem(key: string): string;
+        removeItem(key: string): void;
+        clear(): void;
+    }
+
     export interface ICognitoUserData {
         Username: string;
         Pool: CognitoUserPool;
+        Storage?: ICognitoStorage;
     }
 
     export class CognitoUser {
@@ -92,6 +100,7 @@ declare module "amazon-cognito-identity-js" {
     export interface ICognitoUserPoolData {
         UserPoolId: string;
         ClientId: string;
+        Storage?: ICognitoStorage;
     }
 
     export class CognitoUserPool {

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -74,6 +74,7 @@ export default class CognitoUser {
    * @param {object} data Creation options
    * @param {string} data.Username The user's username.
    * @param {CognitoUserPool} data.Pool Pool containing the user.
+   * @param {object} data.Storage Optional storage object.
    */
   constructor(data) {
     if (data == null || data.Username == null || data.Pool == null) {
@@ -89,7 +90,7 @@ export default class CognitoUser {
     this.signInUserSession = null;
     this.authenticationFlowType = 'USER_SRP_AUTH';
 
-    this.storage = new StorageHelper().getStorage();
+    this.storage = data.Storage || new StorageHelper().getStorage();
   }
 
   /**

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -27,6 +27,7 @@ export default class CognitoUserPool {
    * @param {object} data Creation options.
    * @param {string} data.UserPoolId Cognito user pool id.
    * @param {string} data.ClientId User pool application client id.
+   * @param {object} data.Storage Optional storage object.
    */
   constructor(data) {
     const { UserPoolId, ClientId } = data || {};
@@ -43,7 +44,7 @@ export default class CognitoUserPool {
 
     this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19', region });
 
-    this.storage = new StorageHelper().getStorage();
+    this.storage = data.Storage || new StorageHelper().getStorage();
   }
 
   /**
@@ -89,6 +90,7 @@ export default class CognitoUserPool {
       const cognitoUser = {
         Username: username,
         Pool: this,
+        Storage: this.storage,
       };
 
       const returnData = {
@@ -114,6 +116,7 @@ export default class CognitoUserPool {
       const cognitoUser = {
         Username: lastAuthUser,
         Pool: this,
+        Storage: this.storage,
       };
 
       return new CognitoUser(cognitoUser);


### PR DESCRIPTION
Comments desired!

This change allows consumers to specify a Storage object when creating a `CognitoUserPool` or `CognitoUser`. Users created from a UserPool inherit the Pool’s storage.

This is currently possible by overwriting the storage property after object creation:

```js
let pool = new CognitoUserPool({ UserPoolId, ClientId });
pool.storage = new MyStorage();
```

I’ve successfully been able to use a different storage using this admittedly undocumented mechanism. See here: https://github.com/paulcwatts/ember-cognito/blob/master/addon/authenticators/cognito.js

This commit makes this ability explicit, remains backward compatible, and is a simpler change than what was proposed in #87.