### PR TITLE
Removed the unnecessary result variable on if statement from resendConfirmationCode

### DIFF
--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -809,7 +809,7 @@ export default class CognitoUser {
       ClientId: this.pool.getClientId(),
       Username: this.username,
     }, (err, result) => {
-      if (err, result) {
+      if (err) {
         return callback(err, null);
       }
       return callback(null, result);


### PR DESCRIPTION
This PR, remove the variable `result` from if statement. Related to #390 