### PR TITLE
Remove aws-sdk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,41 +20,27 @@ Your users will benefit from a number of security features including SMS-based M
 Setup
 =====
 
-The Amazon Cognito Identity SDK for JavaScript depends on:
-
-1. The `CognitoIdentityServiceProvider` service from the [AWS SDK for JavaScript](https://github.com/aws/aws-sdk-js)
-
 There are two ways to install the Amazon Cognito Identity SDK for JavaScript and its dependencies,
 depending on your project setup and experience with modern JavaScript build tools:
 
-* Download each JavaScript library and include them in your HTML, or
+* Download the JavaScript library and include it in your HTML, or
 
 * Install the dependencies with npm and use a bundler like webpack.
 
-## Install using separate JavaScript files
+**Note:** This library uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). For [older browsers](https://caniuse.com/#feat=fetch) or in Node.js, you may need to include a polyfill.
+
+## Install using separate JavaScript file
 
 This method is simpler and does not require additional tools, but may have worse performance due to
 the browser having to download multiple files.
 
-Download each of the following JavaScript files for the required libraries and place them in your
-project:
-
-1. The Amazon Cognito AWS SDK for JavaScript, from
-   [/dist/aws-cognito-sdk.min.js](https://raw.githubusercontent.com/aws/amazon-cognito-identity-js/master/dist/aws-cognito-sdk.min.js)
-
-   Note that the Amazon Cognito AWS SDK for JavaScript is just a slimmed down version of the AWS
-   Javascript SDK namespaced as `AWSCognito` instead of `AWS`. It references only the Amazon
-   Cognito Identity service.
-
-3. The Amazon Cognito Identity SDK for JavaScript, from
-   [/dist/amazon-cognito-identity.min.js](https://raw.githubusercontent.com/aws/amazon-cognito-identity-js/master/dist/amazon-cognito-identity.min.js)
+Download the JavaScript [library file](https://raw.githubusercontent.com/aws/amazon-cognito-identity-js/master/dist/amazon-cognito-identity.min.js) and place it in your project.
 
 Optionally, to use other AWS services, include a build of the [AWS SDK for JavaScript](http://aws.amazon.com/sdk-for-browser/).
 
 Include all of the files in your HTML page before calling any Amazon Cognito Identity SDK APIs:
 
 ```html
-    <script src="/path/to/aws-cognito-sdk.min.js"></script>
     <script src="/path/to/amazon-cognito-identity.min.js"></script>
     <!-- optional: only if you use other AWS services -->
     <script src="/path/to/aws-sdk-2.6.10.js"></script>
@@ -193,9 +179,6 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
     // When using loose Javascript files:
     var CognitoUserPool = AmazonCognitoIdentity.CognitoUserPool;
 
-    // Under the original name:
-    var CognitoUserPool = AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool;
-
     // Modules, e.g. Webpack:
     var AmazonCognitoIdentity = require('amazon-cognito-identity-js');
     var CognitoUserPool = AmazonCognitoIdentity.CognitoUserPool;
@@ -212,7 +195,7 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
         UserPoolId : '...', // Your user pool id here
         ClientId : '...' // Your client id here
     };
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+    var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
 
     var attributeList = [];
 
@@ -225,8 +208,8 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
         Name : 'phone_number',
         Value : '+15555555555'
     };
-    var attributeEmail = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(dataEmail);
-    var attributePhoneNumber = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(dataPhoneNumber);
+    var attributeEmail = new AmazonCognitoIdentity.CognitoUserAttribute(dataEmail);
+    var attributePhoneNumber = new AmazonCognitoIdentity.CognitoUserAttribute(dataPhoneNumber);
 
     attributeList.push(attributeEmail);
     attributeList.push(attributePhoneNumber);
@@ -249,13 +232,13 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
         ClientId : '...' // Your client id here
     };
 
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+    var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
     var userData = {
         Username : 'username',
         Pool : userPool
     };
 
-    var cognitoUser = new AWSCognito.CognitoIdentityServiceProvider.CognitoUser(userData);
+    var cognitoUser = new AmazonCognitoIdentity.CognitoUser(userData);
     cognitoUser.confirmRegistration('123456', true, function(err, result) {
         if (err) {
             alert(err);
@@ -285,17 +268,17 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
         Username : 'username',
         Password : 'password',
     };
-    var authenticationDetails = new AWSCognito.CognitoIdentityServiceProvider.AuthenticationDetails(authenticationData);
+    var authenticationDetails = new AmazonCognitoIdentity.AuthenticationDetails(authenticationData);
     var poolData = {
         UserPoolId : '...', // Your user pool id here
         ClientId : '...' // Your client id here
     };
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+    var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
     var userData = {
         Username : 'username',
         Pool : userPool
     };
-    var cognitoUser = new AWSCognito.CognitoIdentityServiceProvider.CognitoUser(userData);
+    var cognitoUser = new AmazonCognitoIdentity.CognitoUser(userData);
     cognitoUser.authenticateUser(authenticationDetails, {
         onSuccess: function (result) {
             console.log('access token + ' + result.getAccessToken().getJwtToken());
@@ -310,7 +293,7 @@ The usage examples below use the unqualified names for types in the Amazon Cogni
                     'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>' : result.getIdToken().getJwtToken()
                 }
             });
-            
+
             //refreshes credentials using AWS.CognitoIdentity.getCredentialsForIdentity()
             AWS.config.credentials.refresh((error) => {
                 if (error) {
@@ -390,7 +373,7 @@ Note that the inputVerificationCode method needs to be defined but does not need
         Name : 'nickname',
         Value : 'joe'
     };
-    var attribute = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserAttribute(attribute);
+    var attribute = new AmazonCognitoIdentity.CognitoUserAttribute(attribute);
     attributeList.push(attribute);
 
     cognitoUser.updateAttributes(attributeList, function(err, result) {
@@ -501,8 +484,8 @@ In React Native, loading the persisted current user information requires an extr
       UserPoolId : '...', // Your user pool id here
       ClientId : '...' // Your client id here
     };
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
-    
+    var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
+
     userPool.storage.sync(function(err, result) {
       if (err) { }
       else if (result === 'SUCCESS') {
@@ -519,7 +502,7 @@ In React Native, loading the persisted current user information requires an extr
         UserPoolId : '...', // Your user pool id here
         ClientId : '...' // Your client id here
     };
-    var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+    var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
     var cognitoUser = userPool.getCurrentUser();
 
     if (cognitoUser != null) {
@@ -733,15 +716,15 @@ To use the CookieStorage you have to pass it in the constructor map of CognitoUs
   var poolData = {
       UserPoolId : '...', // Your user pool id here
       ClientId : '...' // Your client id here
-      Storage: new AWSCognito.CognitoIdentityServiceProvider.CookieStorage({domain: ".yourdomain.com"})
+      Storage: new AmazonCognitoIdentity.CookieStorage({domain: ".yourdomain.com"})
   };
 
-  var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+  var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
 
   var userData = {
       Username: 'username',
       Pool: userPool,
-      Storage: new AWSCognito.CognitoIdentityServiceProvider.CookieStorage({domain: ".yourdomain.com"})
+      Storage: new AmazonCognitoIdentity.CookieStorage({domain: ".yourdomain.com"})
   };
   ```
 The CookieStorage object receives a map (data) in its constructor that may have these values:
@@ -757,23 +740,23 @@ The CookieStorage object receives a map (data) in its constructor that may have 
             Username : 'username',
             Password : 'password',
         };
-        var authenticationDetails = new AWSCognito.CognitoIdentityServiceProvider.AuthenticationDetails(authenticationData);
+        var authenticationDetails = new AmazonCognitoIdentity.AuthenticationDetails(authenticationData);
         var poolData = {
             UserPoolId : '...', // Your user pool id here
             ClientId : '...' // Your client id here
         };
-        var userPool = new AWSCognito.CognitoIdentityServiceProvider.CognitoUserPool(poolData);
+        var userPool = new AmazonCognitoIdentity.CognitoUserPool(poolData);
         var userData = {
             Username : 'username',
             Pool : userPool
         };
-        var cognitoUser = new AWSCognito.CognitoIdentityServiceProvider.CognitoUser(userData);
+        var cognitoUser = new AmazonCognitoIdentity.CognitoUser(userData);
 
         cognitoUser.authenticateUser(authenticationDetails, {
             onSuccess: function (result) {
                 console.log('access token + ' + result.getAccessToken().getJwtToken());
             },
-      
+
             onFailure: function(err) {
                 alert(err);
             },
@@ -947,7 +930,7 @@ In order to authenticate with the Amazon Cognito Identity Service, the client ne
    * Webpack support.
    * Support for Custom authentication flows. Developers can implement custom authentication flows around Cognito Your User Pools. See developer documentation for details.
    * Devices support in User Pools. Users can remember devices and skip MFA verification for remembered devices.
-   * Scopes to control permissions for attributes in a User Pool.  
+   * Scopes to control permissions for attributes in a User Pool.
    * Configurable expiration time for refresh tokens.
    * Set custom FROM and REPLY-TO for email verification messages.
    * Search users in your pool using user attributes.

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ For most frameworks you can whitelist the domain by whitelisting all AWS endpoin
 
 ## Random numbers
 
-In order to authenticate with the Amazon Cognito Identity Service, the client needs to generate a random number as part of the SRP protocol. The AWS SDK is only compatible with modern browsers, and these include support for cryptographically strong random values. If you do need to support older browsers then you should be aware that this is less secure, and if possible include a strong polyfill for `window.crypto.getRandomValues()` before including this library.
+In order to authenticate with the Amazon Cognito Identity Service, the client needs to generate a random number as part of the SRP protocol. The AWS SDK is only compatible with modern browsers, and these include [support for cryptographically strong random values](https://caniuse.com/#feat=cryptography). If you do need to support older browsers then you should include a strong polyfill for `window.crypto.getRandomValues()` before including this library.
 
 ## Change Log
 

--- a/enhance-rn.js
+++ b/enhance-rn.js
@@ -1,17 +1,11 @@
-import AWS from 'aws-sdk/global';
 import { NativeModules } from 'react-native';
-import * as enhancements from './src';
+import * as src from './src';
 
 import BigInteger from './src/BigInteger';
 
 export * from './src';
 
-
 const { RNAWSCognito } = NativeModules;
-
-Object.keys(enhancements).forEach(key => {
-  AWS.CognitoIdentityServiceProvider[key] = enhancements[key];
-});
 
 BigInteger.prototype.modPow = function nativeModPow(e, m, callback) {
   RNAWSCognito.computeModPow({
@@ -27,7 +21,7 @@ BigInteger.prototype.modPow = function nativeModPow(e, m, callback) {
   });
 };
 
-enhancements.AuthenticationHelper.prototype.calculateS =
+src.AuthenticationHelper.prototype.calculateS =
 function nativeComputeS(xValue, serverBValue, callback) {
   RNAWSCognito.computeS({
     g: this.g.toString(16),
@@ -45,15 +39,3 @@ function nativeComputeS(xValue, serverBValue, callback) {
   });
   return undefined;
 };
-
-const libraryVersion = '1.0';
-const libraryName = 'aws-amplify';
-const originalUserAgent = AWS.util.userAgent;
-if (originalUserAgent) {
-  AWS.util.userAgent = function newUserAgent() {
-    return `${libraryName}/${libraryVersion} ${originalUserAgent()}`;
-  };
-} else {
-  const previousUserAgent = AWS.config.customUserAgent || '';
-  AWS.config.update({ customUserAgent: `${libraryName}/${libraryVersion} ${previousUserAgent}` });
-}

--- a/enhance.js
+++ b/enhance.js
@@ -1,8 +1,0 @@
-import CognitoIdentityServiceProvider from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import * as enhancements from './src';
-
-export * from './src';
-
-Object.keys(enhancements).forEach(key => {
-  CognitoIdentityServiceProvider[key] = enhancements[key];
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-cognito-identity-js",
-  "version": "1.22.0",
+  "version": "1.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -44,14 +44,12 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
         "json-stable-stringify": "1.0.1"
       }
     },
@@ -90,6 +88,15 @@
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -100,6 +107,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "anymatch": {
@@ -248,9 +261,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -267,23 +280,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "aws-sdk": {
-      "version": "2.133.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.133.0.tgz",
-      "integrity": "sha1-am2JiL01kowRu9PbZ3rVs+rnEHo=",
-      "requires": {
-        "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
-        "events": "1.1.1",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
-      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -308,8 +304,8 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
+        "commander": "2.12.2",
+        "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -347,7 +343,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
@@ -356,14 +352,6 @@
         "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        }
       }
     },
     "babel-generator": {
@@ -952,16 +940,10 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -1100,19 +1082,11 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1121,22 +1095,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
-        }
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1239,9 +1199,9 @@
       "dev": true
     },
     "big-integer": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
-      "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM=",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+      "integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg=",
       "dev": true
     },
     "big.js": {
@@ -1251,9 +1211,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bluebird": {
@@ -1341,7 +1301,7 @@
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
       "dev": true,
       "requires": {
-        "big-integer": "1.6.25"
+        "big-integer": "1.6.26"
       }
     },
     "brace-expansion": {
@@ -1611,9 +1571,9 @@
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
       "dev": true
     },
     "clone-stats": {
@@ -1634,6 +1594,12 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1644,9 +1610,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "commondir": {
@@ -1656,9 +1622,9 @@
       "dev": true
     },
     "compressible": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
-      "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
       "dev": true,
       "requires": {
         "mime-db": "1.30.0"
@@ -1672,7 +1638,7 @@
       "requires": {
         "accepts": "1.2.13",
         "bytes": "2.1.0",
-        "compressible": "2.0.11",
+        "compressible": "2.0.12",
         "debug": "2.2.0",
         "on-headers": "1.0.1",
         "vary": "1.0.1"
@@ -1825,9 +1791,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "cookie": {
@@ -1853,9 +1819,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
       "dev": true
     },
     "core-util-is": {
@@ -1914,28 +1880,16 @@
       "requires": {
         "cross-spawn": "5.1.0",
         "is-windows": "1.0.1"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        }
       }
     },
     "cross-spawn": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
     },
@@ -1999,7 +1953,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "dashdash": {
@@ -2120,13 +2074,12 @@
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom-walk": {
@@ -2234,12 +2187,12 @@
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -2289,9 +2242,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.35",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -2305,7 +2258,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2316,7 +2269,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -2330,7 +2283,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -2343,7 +2296,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -2353,7 +2306,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -2392,7 +2345,7 @@
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
         "debug": "2.6.9",
-        "doctrine": "2.0.0",
+        "doctrine": "2.0.2",
         "escope": "3.6.0",
         "espree": "3.5.2",
         "esquery": "1.0.0",
@@ -2404,8 +2357,8 @@
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.0.1",
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
@@ -2425,12 +2378,6 @@
         "user-home": "2.0.0"
       },
       "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
         "user-home": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -2468,7 +2415,7 @@
         "debug": "2.6.9",
         "enhanced-resolve": "0.9.1",
         "find-root": "0.1.2",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "is-absolute": "0.2.6",
         "lodash.get": "3.7.0",
         "node-libs-browser": "1.1.1",
@@ -2514,63 +2461,6 @@
             "esutils": "2.0.2",
             "isarray": "1.0.0"
           }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
         }
       }
     },
@@ -2666,7 +2556,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "event-target-shim": {
@@ -2678,7 +2568,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -2788,12 +2679,13 @@
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
     },
@@ -2801,6 +2693,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2842,6 +2740,14 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
       }
     },
     "fbjs-scripts": {
@@ -2890,6 +2796,22 @@
             "babel-plugin-transform-flow-strip-types": "6.22.0",
             "babel-plugin-transform-object-rest-spread": "6.26.0",
             "object-assign": "4.1.1"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         }
       }
@@ -3065,6 +2987,17 @@
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0",
         "klaw": "1.3.1"
+      },
+      "dependencies": {
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
       }
     },
     "fs-readdir-recursive": {
@@ -3086,7 +3019,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
+        "nan": "2.8.0",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -3853,14 +3786,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3869,6 +3794,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4073,6 +4006,14 @@
       "requires": {
         "min-document": "2.19.0",
         "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+          "dev": true
+        }
       }
     },
     "globals": {
@@ -4121,7 +4062,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "2.2.0",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -4136,6 +4077,12 @@
         "vinyl": "0.5.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -4165,8 +4112,22 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "has": {
@@ -4236,7 +4197,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       },
       "dependencies": {
         "hoek": {
@@ -4287,7 +4248,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       }
     },
     "http-signature": {
@@ -4386,9 +4347,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invariant": {
@@ -4436,13 +4397,13 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -4509,9 +4470,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -4541,13 +4502,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -4581,13 +4542,10 @@
       }
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4664,17 +4622,24 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jest-docblock": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+      "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+      "dev": true
+    },
     "jest-haste-map": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-19.0.0.tgz",
-      "integrity": "sha1-rd4Atisf4EQyoQSzJU/FAEUUtV4=",
+      "version": "20.0.5",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
+      "integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
+        "jest-docblock": "20.0.3",
         "micromatch": "2.3.11",
-        "sane": "1.5.0",
-        "worker-farm": "1.5.0"
+        "sane": "1.6.0",
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
         "bser": {
@@ -4686,10 +4651,16 @@
             "node-int64": "0.4.0"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "sane": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-1.5.0.tgz",
-          "integrity": "sha1-pK3q52TQSGIeyyfV+ez1ExAZOfM=",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+          "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
           "dev": true,
           "requires": {
             "anymatch": "1.3.2",
@@ -4714,11 +4685,6 @@
         }
       }
     },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
     "joi": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
@@ -4727,9 +4693,14 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.19.1",
+        "moment": "2.20.1",
         "topo": "1.1.0"
       }
+    },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -4775,7 +4746,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.7",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -4788,15 +4759,6 @@
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
           "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
           "dev": true
-        },
-        "klaw": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-          "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
         }
       }
     },
@@ -4834,9 +4796,9 @@
       "dev": true
     },
     "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
@@ -4878,13 +4840,13 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
@@ -4906,9 +4868,9 @@
       }
     },
     "left-pad": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
-      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
       "dev": true
     },
     "levn": {
@@ -4922,16 +4884,15 @@
       }
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "strip-bom": "3.0.0"
       }
     },
     "loader-utils": {
@@ -4944,14 +4905,6 @@
         "emojis-list": "2.1.0",
         "json5": "0.5.1",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        }
       }
     },
     "locate-path": {
@@ -4975,7 +4928,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -5180,9 +5134,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "md5.js": {
@@ -5283,9 +5237,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -5342,9 +5296,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
@@ -5354,20 +5308,12 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
       }
     },
     "moment": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
       "dev": true
     },
     "morgan": {
@@ -5458,9 +5404,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -5510,7 +5456,7 @@
         "os-browserify": "0.2.1",
         "path-browserify": "0.0.0",
         "process": "0.11.10",
-        "punycode": "1.3.2",
+        "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
@@ -5542,27 +5488,11 @@
             "randomfill": "1.0.3"
           }
         },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
-        },
-        "url": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          }
         }
       }
     },
@@ -5671,16 +5601,10 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
+        "minimist": "0.0.8",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -5842,14 +5766,12 @@
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "pify": "2.3.0"
       }
     },
     "pause": {
@@ -5936,21 +5858,6 @@
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
           "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
           "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "xmlbuilder": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-          "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
-          "dev": true,
-          "requires": {
-            "lodash": "3.10.1"
-          }
         }
       }
     },
@@ -5985,9 +5892,9 @@
       "dev": true
     },
     "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
@@ -6011,10 +5918,21 @@
         "asap": "2.0.6"
       }
     },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -6037,9 +5955,10 @@
       }
     },
     "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "qs": {
       "version": "4.0.0",
@@ -6050,7 +5969,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -6089,7 +6009,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6100,7 +6020,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6156,14 +6076,15 @@
       }
     },
     "react": {
-      "version": "16.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.0.0-alpha.6.tgz",
-      "integrity": "sha1-LMsa+0QlzMEveKEjpmby5MFBrbk=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "react-clone-referenced-element": {
@@ -6201,20 +6122,20 @@
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1",
-            "ultron": "1.1.0"
+            "ultron": "1.1.1"
           }
         }
       }
     },
     "react-native": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.44.0.tgz",
-      "integrity": "sha1-BkJ6MAU/LVVcYP4LmvzGx3jbCd4=",
+      "version": "0.44.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.44.3.tgz",
+      "integrity": "sha1-BFUOHN/GGacS8/WWnWjNfC3EwHM=",
       "dev": true,
       "requires": {
         "absolute-path": "0.0.0",
         "art": "0.10.1",
-        "async": "2.5.0",
+        "async": "2.6.0",
         "babel-core": "6.26.0",
         "babel-generator": "6.26.0",
         "babel-plugin-external-helpers": "6.22.0",
@@ -6234,10 +6155,10 @@
         "base64-js": "1.2.1",
         "bser": "1.0.3",
         "chalk": "1.1.3",
-        "commander": "2.11.0",
+        "commander": "2.12.2",
         "concat-stream": "1.6.0",
         "connect": "2.30.2",
-        "core-js": "2.5.1",
+        "core-js": "2.5.3",
         "debug": "2.6.9",
         "denodeify": "1.2.1",
         "event-target-shim": "1.1.1",
@@ -6251,13 +6172,13 @@
         "immutable": "3.7.6",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "jest-haste-map": "19.0.0",
+        "jest-haste-map": "20.0.5",
         "joi": "6.10.1",
         "json-stable-stringify": "1.0.1",
         "json5": "0.4.0",
-        "left-pad": "1.1.3",
+        "left-pad": "1.2.0",
         "lodash": "4.17.4",
-        "mime": "1.4.1",
+        "mime": "1.6.0",
         "mime-types": "2.1.11",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
@@ -6286,19 +6207,31 @@
         "uglify-js": "2.7.5",
         "whatwg-fetch": "1.1.1",
         "wordwrap": "1.0.0",
-        "worker-farm": "1.5.0",
+        "worker-farm": "1.5.2",
         "write-file-atomic": "1.3.4",
-        "ws": "1.1.4",
+        "ws": "1.1.5",
         "xcode": "0.9.3",
         "xmldoc": "0.4.0",
         "xpipe": "1.0.5",
         "yargs": "6.6.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
           "dev": true
         },
         "whatwg-fetch": {
@@ -6336,24 +6269,35 @@
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
+        "load-json-file": "2.0.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -6416,9 +6360,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-      "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regenerator-transform": {
@@ -6723,13 +6667,20 @@
           "requires": {
             "bser": "1.0.2"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
     "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA=",
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
@@ -6917,7 +6868,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -6976,9 +6927,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
         "hoek": "4.2.0"
@@ -7069,9 +7020,9 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stream-browserify": {
@@ -7138,15 +7089,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7156,6 +7098,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -7174,13 +7125,10 @@
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -7208,16 +7156,6 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -7322,14 +7260,6 @@
       "dev": true,
       "requires": {
         "process": "0.11.10"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        }
       }
     },
     "tmpl": {
@@ -7366,26 +7296,12 @@
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
       }
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tsscmp": {
@@ -7506,9 +7422,9 @@
       }
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "unc-path-regex": {
@@ -7547,12 +7463,21 @@
       "dev": true
     },
     "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
       }
     },
     "user-home": {
@@ -7593,7 +7518,8 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
@@ -7643,7 +7569,7 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
+        "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -7699,7 +7625,7 @@
       "requires": {
         "acorn": "3.3.0",
         "async": "1.5.2",
-        "clone": "1.0.2",
+        "clone": "1.0.3",
         "enhanced-resolve": "0.9.1",
         "interpret": "0.6.6",
         "loader-utils": "0.2.17",
@@ -7759,7 +7685,7 @@
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
+            "errno": "0.1.6",
             "readable-stream": "2.3.3"
           }
         },
@@ -7781,7 +7707,7 @@
             "os-browserify": "0.2.1",
             "path-browserify": "0.0.0",
             "process": "0.11.10",
-            "punycode": "1.3.2",
+            "punycode": "1.4.1",
             "querystring-es3": "0.2.1",
             "readable-stream": "2.3.3",
             "stream-browserify": "2.0.1",
@@ -7793,12 +7719,6 @@
             "util": "0.10.3",
             "vm-browserify": "0.0.4"
           }
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
         },
         "ripemd160": {
           "version": "0.2.0",
@@ -7834,16 +7754,6 @@
           "dev": true,
           "requires": {
             "setimmediate": "1.0.5"
-          }
-        },
-        "url": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
           }
         }
       }
@@ -7903,12 +7813,12 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
-      "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.6",
         "xtend": "4.0.1"
       }
     },
@@ -7949,9 +7859,9 @@
       }
     },
     "ws": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
-      "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
         "options": "0.0.6",
@@ -7985,21 +7895,21 @@
         }
       }
     },
-    "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
-      }
-    },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+      "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
+      "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "xmlcreate": {
@@ -8015,14 +7925,6 @@
       "dev": true,
       "requires": {
         "sax": "1.1.6"
-      },
-      "dependencies": {
-        "sax": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
-          "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA=",
-          "dev": true
-        }
       }
     },
     "xmldom": {
@@ -8091,6 +7993,60 @@
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,7 +1374,7 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1524,7 +1524,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -1850,7 +1849,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
@@ -1862,7 +1860,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
@@ -1918,11 +1915,6 @@
           "dev": true
         }
       }
-    },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
     },
     "csrf": {
       "version": "3.0.6",
@@ -2070,7 +2062,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "doctrine": {
@@ -4173,7 +4165,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -4322,8 +4313,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -5484,7 +5474,7 @@
             "inherits": "2.0.3",
             "pbkdf2": "3.0.14",
             "public-encrypt": "4.0.0",
-            "randombytes": "2.0.5",
+            "randombytes": "2.0.6",
             "randomfill": "1.0.3"
           }
         },
@@ -5951,7 +5941,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -6026,10 +6016,9 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -6040,7 +6029,7 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -6603,7 +6592,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
@@ -6633,8 +6621,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "1.4.1",
@@ -6828,7 +6815,6 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"

--- a/package.json
+++ b/package.json
@@ -61,8 +61,10 @@
   "types": "./index.d.ts",
   "dependencies": {
     "buffer": "4.9.1",
-    "crypto-browserify": "1.0.9",
-    "js-cookie": "^2.1.4"
+    "create-hash": "^1.1.3",
+    "create-hmac": "^1.1.6",
+    "js-cookie": "^2.1.4",
+    "randombytes": "^2.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
   "types": "./index.d.ts",
   "dependencies": {
     "aws-sdk": "^2.6.0",
+    "buffer": "4.9.1",
+    "crypto-browserify": "1.0.9",
     "js-cookie": "^2.1.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "jsnext:main": "es/index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "aws-sdk": "^2.6.0",
     "buffer": "4.9.1",
     "crypto-browserify": "1.0.9",
     "js-cookie": "^2.1.4"

--- a/src/AuthenticationDetails.js
+++ b/src/AuthenticationDetails.js
@@ -27,8 +27,8 @@ export default class AuthenticationDetails {
    */
   constructor(data) {
     const { ValidationData, Username, Password, AuthParameters } = data || {};
-    this.validationData = ValidationData || [];
-    this.authParameters = AuthParameters || [];
+    this.validationData = ValidationData || {};
+    this.authParameters = AuthParameters || {};
     this.username = Username;
     this.password = Password;
   }

--- a/src/AuthenticationHelper.js
+++ b/src/AuthenticationHelper.js
@@ -16,7 +16,9 @@
  */
 
 import { Buffer } from 'buffer/';
-import { randomBytes, createHmac, createHash } from 'crypto-browserify';
+import randomBytes from 'randombytes';
+import createHmac from 'create-hmac';
+import createHash from 'create-hash';
 
 import BigInteger from './BigInteger';
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,0 +1,68 @@
+/** @class */
+export default class Client {
+  /**
+   * Constructs a new AWS Cognito Identity Provider client object
+   * @param {string} region AWS region.
+   * @param {string} endpoint endpoint
+   */
+  constructor(region, endpoint) {
+    this.endpoint = endpoint || `https://cognito-idp.${region}.amazonaws.com/`;
+  }
+
+  /**
+   * Makes an unauthenticated request on AWS Cognito Identity Provider API
+   * using fetch
+   * @param {string} operation API operation
+   * @param {object} params Input parameters
+   * @param {function} callback Callback called when a response is returned
+   * @returns {void}
+  */
+  request(operation, params, callback) {
+    const headers = {
+      'Content-Type': 'application/x-amz-json-1.1',
+      'X-Amz-Target': `AWSCognitoIdentityProviderService.${operation}`,
+      'X-Amz-User-Agent': 'amazon-cognito-identity-js',
+    };
+
+    const options = {
+      headers,
+      method: 'POST',
+      mode: 'cors',
+      cache: 'no-cache',
+      body: JSON.stringify(params),
+    };
+
+    let response;
+
+    fetch(this.endpoint, options)
+      .then(resp => {
+        response = resp;
+        return resp;
+      })
+      .then(resp => resp.json().catch(() => ({})))
+      .then(data => {
+        if (response.ok) return callback(null, data);
+
+        // Taken from aws-sdk-js/lib/protocol/json.js
+        // eslint-disable-next-line no-underscore-dangle
+        const code = (data.__type || data.code).split('#').pop();
+        const error = {
+          code,
+          name: code,
+          message: (data.message || data.Message || null),
+        };
+        return callback(error);
+      })
+      .catch(() => {
+        // Taken from aws-sdk-js/lib/protocol/json.js
+        const code = (response.headers.get('x-amzn-errortype') || 'UnknownError').split(':')[0];
+        const error = {
+          code,
+          name: code,
+          statusCode: response.status,
+          message: response.status.toString(),
+        };
+        return callback(error);
+      });
+  }
+}

--- a/src/Client.js
+++ b/src/Client.js
@@ -21,7 +21,7 @@ export default class Client {
     const headers = {
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': `AWSCognitoIdentityProviderService.${operation}`,
-      'X-Amz-User-Agent': 'amazon-cognito-identity-js',
+      'X-Amz-User-Agent': 'aws-amplify/1.0',
     };
 
     const options = {

--- a/src/CognitoJwtToken.js
+++ b/src/CognitoJwtToken.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/global';
+import { Buffer } from 'buffer/';
 
 /** @class */
 export default class CognitoJwtToken {
@@ -56,7 +56,7 @@ export default class CognitoJwtToken {
   decodePayload() {
     const payload = this.jwtToken.split('.')[1];
     try {
-      return JSON.parse(util.base64.decode(payload).toString('utf8'));
+      return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
     } catch (err) {
       return {};
     }

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/global';
+import { Buffer } from 'buffer/';
+import { createHmac } from 'crypto-browserify';
 
 import BigInteger from './BigInteger';
 import AuthenticationHelper from './AuthenticationHelper';
@@ -252,12 +253,14 @@ export default class CognitoUser {
 
             const dateNow = dateHelper.getNowString();
 
-            const signatureString = util.crypto.hmac(hkdf, util.buffer.concat([
-              new util.Buffer(this.pool.getUserPoolId().split('_')[1], 'utf8'),
-              new util.Buffer(this.username, 'utf8'),
-              new util.Buffer(challengeParameters.SECRET_BLOCK, 'base64'),
-              new util.Buffer(dateNow, 'utf8'),
-            ]), 'base64', 'sha256');
+            const signatureString = createHmac('sha256', hkdf)
+              .update(Buffer.concat([
+                Buffer.from(this.pool.getUserPoolId().split('_')[1], 'utf8'),
+                Buffer.from(this.username, 'utf8'),
+                Buffer.from(challengeParameters.SECRET_BLOCK, 'base64'),
+                Buffer.from(dateNow, 'utf8'),
+              ]))
+              .digest('base64');
 
             const challengeResponses = {};
 
@@ -398,12 +401,12 @@ export default class CognitoUser {
       }
 
       const deviceSecretVerifierConfig = {
-        Salt: new util.Buffer(
-            authenticationHelper.getSaltDevices(), 'hex'
-          ).toString('base64'),
-        PasswordVerifier: new util.Buffer(
-            authenticationHelper.getVerifierDevices(), 'hex'
-          ).toString('base64'),
+        Salt: Buffer.from(
+          authenticationHelper.getSaltDevices(), 'hex'
+        ).toString('base64'),
+        PasswordVerifier: Buffer.from(
+          authenticationHelper.getVerifierDevices(), 'hex'
+        ).toString('base64'),
       };
 
       this.verifierDevices = deviceSecretVerifierConfig.PasswordVerifier;
@@ -543,12 +546,14 @@ export default class CognitoUser {
 
             const dateNow = dateHelper.getNowString();
 
-            const signatureString = util.crypto.hmac(hkdf, util.buffer.concat([
-              new util.Buffer(this.deviceGroupKey, 'utf8'),
-              new util.Buffer(this.deviceKey, 'utf8'),
-              new util.Buffer(challengeParameters.SECRET_BLOCK, 'base64'),
-              new util.Buffer(dateNow, 'utf8'),
-            ]), 'base64', 'sha256');
+            const signatureString = createHmac('sha256', hkdf)
+            .update(Buffer.concat([
+              Buffer.from(this.deviceGroupKey, 'utf8'),
+              Buffer.from(this.deviceKey, 'utf8'),
+              Buffer.from(challengeParameters.SECRET_BLOCK, 'base64'),
+              Buffer.from(dateNow, 'utf8'),
+            ]))
+            .digest('base64');
 
             const challengeResponses = {};
 
@@ -720,12 +725,12 @@ export default class CognitoUser {
               }
 
               const deviceSecretVerifierConfig = {
-                Salt: new util.Buffer(
-                    authenticationHelper.getSaltDevices(), 'hex'
-                  ).toString('base64'),
-                PasswordVerifier: new util.Buffer(
-                    authenticationHelper.getVerifierDevices(), 'hex'
-                  ).toString('base64'),
+                Salt: Buffer.from(
+                  authenticationHelper.getSaltDevices(), 'hex'
+                ).toString('base64'),
+                PasswordVerifier: Buffer.from(
+                  authenticationHelper.getVerifierDevices(), 'hex'
+                ).toString('base64'),
               };
 
               this.verifierDevices = deviceSecretVerifierConfig.PasswordVerifier;

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -16,7 +16,7 @@
  */
 
 import { Buffer } from 'buffer/';
-import { createHmac } from 'crypto-browserify';
+import createHmac from 'create-hmac';
 
 import BigInteger from './BigInteger';
 import AuthenticationHelper from './AuthenticationHelper';

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -160,7 +160,7 @@ export default class CognitoUser {
       jsonReq.UserContextData = this.getUserContextData();
     }
 
-    this.client.makeUnauthenticatedRequest('initiateAuth', jsonReq, (err, data) => {
+    this.client.request('InitiateAuth', jsonReq, (err, data) => {
       if (err) {
         return callback.onFailure(err);
       }
@@ -228,7 +228,7 @@ export default class CognitoUser {
         jsonReq.UserContextData = this.getUserContextData(this.username);
       }
 
-      this.client.makeUnauthenticatedRequest('initiateAuth', jsonReq, (err, data) => {
+      this.client.request('InitiateAuth', jsonReq, (err, data) => {
         if (err) {
           return callback.onFailure(err);
         }
@@ -274,7 +274,7 @@ export default class CognitoUser {
             }
 
             const respondToAuthChallenge = (challenge, challengeCallback) =>
-              this.client.makeUnauthenticatedRequest('respondToAuthChallenge', challenge,
+              this.client.request('RespondToAuthChallenge', challenge,
                 (errChallenge, dataChallenge) => {
                   if (errChallenge && errChallenge.code === 'ResourceNotFoundException' &&
                       errChallenge.message.toLowerCase().indexOf('device') !== -1) {
@@ -413,7 +413,7 @@ export default class CognitoUser {
       this.deviceGroupKey = newDeviceMetadata.DeviceGroupKey;
       this.randomPassword = authenticationHelper.getRandomPassword();
 
-      this.client.makeUnauthenticatedRequest('confirmDevice', {
+      this.client.request('ConfirmDevice', {
         DeviceKey: newDeviceMetadata.DeviceKey,
         AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
         DeviceSecretVerifierConfig: deviceSecretVerifierConfig,
@@ -478,7 +478,7 @@ export default class CognitoUser {
       jsonReq.UserContextData = this.getUserContextData();
     }
 
-    this.client.makeUnauthenticatedRequest('respondToAuthChallenge',
+    this.client.request('RespondToAuthChallenge',
         jsonReq, (errAuthenticate, dataAuthenticate) => {
           if (errAuthenticate) {
             return callback.onFailure(errAuthenticate);
@@ -523,7 +523,7 @@ export default class CognitoUser {
       if (this.getUserContextData()) {
         jsonReq.UserContextData = this.getUserContextData();
       }
-      this.client.makeUnauthenticatedRequest('respondToAuthChallenge', jsonReq, (err, data) => {
+      this.client.request('RespondToAuthChallenge', jsonReq, (err, data) => {
         if (err) {
           return callback.onFailure(err);
         }
@@ -573,7 +573,7 @@ export default class CognitoUser {
               jsonReqResp.UserContextData = this.getUserContextData();
             }
 
-            this.client.makeUnauthenticatedRequest('respondToAuthChallenge',
+            this.client.request('RespondToAuthChallenge',
                 jsonReqResp, (errAuthenticate, dataAuthenticate) => {
                   if (errAuthenticate) {
                     return callback.onFailure(errAuthenticate);
@@ -612,7 +612,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('confirmSignUp', jsonReq, err => {
+    this.client.request('ConfirmSignUp', jsonReq, err => {
       if (err) {
         return callback(err, null);
       }
@@ -643,7 +643,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('respondToAuthChallenge', jsonReq, (err, data) => {
+    this.client.request('RespondToAuthChallenge', jsonReq, (err, data) => {
       if (err) {
         return callback.onFailure(err);
       }
@@ -693,7 +693,7 @@ export default class CognitoUser {
       jsonReq.UserContextData = this.getUserContextData();
     }
 
-    this.client.makeUnauthenticatedRequest('respondToAuthChallenge',
+    this.client.request('RespondToAuthChallenge',
         jsonReq, (err, dataAuthenticate) => {
           if (err) {
             return callback.onFailure(err);
@@ -738,7 +738,7 @@ export default class CognitoUser {
                 .NewDeviceMetadata.DeviceGroupKey;
               this.randomPassword = authenticationHelper.getRandomPassword();
 
-              this.client.makeUnauthenticatedRequest('confirmDevice', {
+              this.client.request('ConfirmDevice', {
                 DeviceKey: dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey,
                 AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
                 DeviceSecretVerifierConfig: deviceSecretVerifierConfig,
@@ -775,7 +775,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('changePassword', {
+    this.client.request('ChangePassword', {
       PreviousPassword: oldUserPassword,
       ProposedPassword: newUserPassword,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
@@ -805,7 +805,7 @@ export default class CognitoUser {
     };
     mfaOptions.push(mfaEnabled);
 
-    this.client.makeUnauthenticatedRequest('setUserSettings', {
+    this.client.request('SetUserSettings', {
       MFAOptions: mfaOptions,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, err => {
@@ -829,7 +829,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('setUserMFAPreference', {
+    this.client.request('SetUserMFAPreference', {
       SMSMfaSettings: smsMfaSettings,
       SoftwareTokenMfaSettings: softwareTokenMfaSettings,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
@@ -854,7 +854,7 @@ export default class CognitoUser {
 
     const mfaOptions = [];
 
-    this.client.makeUnauthenticatedRequest('setUserSettings', {
+    this.client.request('SetUserSettings', {
       MFAOptions: mfaOptions,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, err => {
@@ -877,7 +877,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('deleteUser', {
+    this.client.request('DeleteUser', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, err => {
       if (err) {
@@ -903,7 +903,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('updateUserAttributes', {
+    this.client.request('UpdateUserAttributes', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       UserAttributes: attributes,
     }, err => {
@@ -925,7 +925,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('getUser', {
+    this.client.request('GetUser', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, (err, userData) => {
       if (err) {
@@ -958,7 +958,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('getUser', {
+    this.client.request('GetUser', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, (err, userData) => {
       if (err) {
@@ -981,7 +981,7 @@ export default class CognitoUser {
       return callback(new Error('User is not authenticated'), null);
     }
 
-    this.client.makeUnauthenticatedRequest('deleteUserAttributes', {
+    this.client.request('DeleteUserAttributes', {
       UserAttributeNames: attributeList,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, err => {
@@ -1004,7 +1004,7 @@ export default class CognitoUser {
       Username: this.username,
     };
 
-    this.client.makeUnauthenticatedRequest('resendConfirmationCode', jsonReq, (err, result) => {
+    this.client.request('ResendConfirmationCode', jsonReq, (err, result) => {
       if (err) {
         return callback(err, null);
       }
@@ -1098,7 +1098,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('initiateAuth', jsonReq, (err, authResult) => {
+    this.client.request('InitiateAuth', jsonReq, (err, authResult) => {
       if (err) {
         if (err.code === 'NotAuthorizedException') {
           this.clearCachedTokens();
@@ -1238,7 +1238,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('forgotPassword', jsonReq, (err, data) => {
+    this.client.request('ForgotPassword', jsonReq, (err, data) => {
       if (err) {
         return callback.onFailure(err);
       }
@@ -1268,7 +1268,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('confirmForgotPassword', jsonReq, err => {
+    this.client.request('ConfirmForgotPassword', jsonReq, err => {
       if (err) {
         return callback.onFailure(err);
       }
@@ -1289,7 +1289,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('getUserAttributeVerificationCode', {
+    this.client.request('GetUserAttributeVerificationCode', {
       AttributeName: attributeName,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, (err, data) => {
@@ -1318,7 +1318,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('verifyUserAttribute', {
+    this.client.request('VerifyUserAttribute', {
       AttributeName: attributeName,
       Code: confirmationCode,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
@@ -1343,7 +1343,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('getDevice', {
+    this.client.request('GetDevice', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       DeviceKey: this.deviceKey,
     }, (err, data) => {
@@ -1368,7 +1368,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('forgetDevice', {
+    this.client.request('ForgetDevice', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       DeviceKey: deviceKey,
     }, err => {
@@ -1412,7 +1412,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('updateDeviceStatus', {
+    this.client.request('UpdateDeviceStatus', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       DeviceKey: this.deviceKey,
       DeviceRememberedStatus: 'remembered',
@@ -1437,7 +1437,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('updateDeviceStatus', {
+    this.client.request('UpdateDeviceStatus', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       DeviceKey: this.deviceKey,
       DeviceRememberedStatus: 'not_remembered',
@@ -1465,7 +1465,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('listDevices', {
+    this.client.request('ListDevices', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       Limit: limit,
       PaginationToken: paginationToken,
@@ -1490,7 +1490,7 @@ export default class CognitoUser {
       return callback.onFailure(new Error('User is not authenticated'));
     }
 
-    this.client.makeUnauthenticatedRequest('globalSignOut', {
+    this.client.request('GlobalSignOut', {
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
     }, err => {
       if (err) {
@@ -1531,7 +1531,7 @@ export default class CognitoUser {
     if (this.getUserContextData()) {
       jsonReq.UserContextData = this.getUserContextData();
     }
-    this.client.makeUnauthenticatedRequest('respondToAuthChallenge', jsonReq, (err, data) => {
+    this.client.request('RespondToAuthChallenge', jsonReq, (err, data) => {
       if (err) {
         return callback.onFailure(err);
       }
@@ -1562,7 +1562,7 @@ export default class CognitoUser {
    */
   associateSoftwareToken(callback) {
     if (!(this.signInUserSession != null && this.signInUserSession.isValid())) {
-      this.client.makeUnauthenticatedRequest('associateSoftwareToken', {
+      this.client.request('AssociateSoftwareToken', {
         Session: this.Session,
       }, (err, data) => {
         if (err) {
@@ -1572,7 +1572,7 @@ export default class CognitoUser {
         return callback.associateSecretCode(data.SecretCode);
       });
     } else {
-      this.client.makeUnauthenticatedRequest('associateSoftwareToken', {
+      this.client.request('AssociateSoftwareToken', {
         AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       }, (err, data) => {
         if (err) {
@@ -1592,7 +1592,7 @@ export default class CognitoUser {
    */
   verifySoftwareToken(totpCode, friendlyDeviceName, callback) {
     if (!(this.signInUserSession != null && this.signInUserSession.isValid())) {
-      this.client.makeUnauthenticatedRequest('verifySoftwareToken', {
+      this.client.request('VerifySoftwareToken', {
         Session: this.Session,
         UserCode: totpCode,
         FriendlyDeviceName: friendlyDeviceName,
@@ -1612,7 +1612,7 @@ export default class CognitoUser {
         if (this.getUserContextData()) {
           jsonReq.UserContextData = this.getUserContextData();
         }
-        this.client.makeUnauthenticatedRequest('respondToAuthChallenge',
+        this.client.request('RespondToAuthChallenge',
             jsonReq, (errRespond, dataRespond) => {
               if (errRespond) {
                 return callback.onFailure(errRespond);
@@ -1624,7 +1624,7 @@ export default class CognitoUser {
         return undefined;
       });
     } else {
-      this.client.makeUnauthenticatedRequest('verifySoftwareToken', {
+      this.client.request('VerifySoftwareToken', {
         AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
         UserCode: totpCode,
         FriendlyDeviceName: friendlyDeviceName,

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import CognitoIdentityServiceProvider from 'aws-sdk/clients/cognitoidentityserviceprovider';
-
+import Client from './Client';
 import CognitoUser from './CognitoUser';
 import StorageHelper from './StorageHelper';
 
@@ -46,11 +45,7 @@ export default class CognitoUserPool {
     this.userPoolId = UserPoolId;
     this.clientId = ClientId;
 
-    this.client = new CognitoIdentityServiceProvider({
-      apiVersion: '2016-04-19',
-      region,
-      endpoint,
-    });
+    this.client = new Client(region, endpoint);
 
     /**
      * By default, AdvancedSecurityDataCollectionFlag is set to true,
@@ -100,7 +95,7 @@ export default class CognitoUserPool {
     if (this.getUserContextData(username)) {
       jsonReq.UserContextData = this.getUserContextData(username);
     }
-    this.client.makeUnauthenticatedRequest('signUp', jsonReq, (err, data) => {
+    this.client.request('SignUp', jsonReq, (err, data) => {
       if (err) {
         return callback(err, null);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,3 @@ export { default as CognitoUserPool } from './CognitoUserPool';
 export { default as CognitoUserSession } from './CognitoUserSession';
 export { default as CookieStorage } from './CookieStorage';
 export { default as DateHelper } from './DateHelper';
-
-// The version of crypto-browserify included by aws-sdk only
-// checks for window.crypto, not window.msCrypto as used by
-// IE 11 – so we set it explicitly here
-if (typeof window !== 'undefined' && !window.crypto && window.msCrypto) {
-  window.crypto = window.msCrypto;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,26 +19,10 @@ var banner = '/*!\n' +
 ' */\n\n';
 
 var config = {
-  entry: './enhance',
+  entry: './src/index.js',
   output: {
     libraryTarget: 'umd',
     library: 'AmazonCognitoIdentity'
-  },
-  externals: {
-    // This umd context config isn't in configuration documentation, but see example:
-    // https://github.com/webpack/webpack/tree/master/examples/externals
-    'aws-sdk/global': {
-      root: ['AWSCognito'],
-      commonjs2: 'aws-sdk/global',
-      commonjs: 'aws-sdk/global',
-      amd: 'aws-sdk/global'
-    },
-    'aws-sdk/clients/cognitoidentityserviceprovider': {
-      root: ['AWSCognito', 'CognitoIdentityServiceProvider'],
-      commonjs2: 'aws-sdk/clients/cognitoidentityserviceprovider',
-      commonjs: 'aws-sdk/clients/cognitoidentityserviceprovider',
-      amd: 'aws-sdk/clients/cognitoidentityserviceprovider'
-    },
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
This PR completely removes the `aws-sdk` dependency.
* `util` is removed by using `buffer` and `crypto-browserify` directly (same versions as those used by the `aws-sdk`)
* `CognitoIdentityServiceProvider` is replaced by a `fetch` client (with a polyfill for older browers using `whatwg-fetch`)

The idea behind this PR is that this library makes only unauthenticated calls to AWS, but due to the structure of the `aws-sdk`, a lot gets imported when bundling, see below (using `webpack-bundle-analyzer`):

![image](https://user-images.githubusercontent.com/12623249/28119090-e809fff0-6713-11e7-917b-efd8c4af64f2.png)

The `dist` files are not included in this PR but here is an idea of the sizes:
* Before: amazon-cognito-identity.min.js 43.6 KB (10 KB gz) + aws-cognito-sdk.min.js 253 KB (65.8 KB gz) = 296.6 KB (75.8 KB gz)
* After: amazon-cognito-identity.min.js 98.9 KB (26.9 KB gz)

I would be happy to discuss this proposal with the people from AWS before going further with changes (update doc, webpack config, build, ...)

**Note**: Because the [JSON schema of the API](https://github.com/aws/aws-sdk-js/blob/master/apis/cognito-idp-2016-04-18.normal.json) is not used to parse/format the http response, the response objects (in js) are slightly different, e.g. when using `ListDevices` dates are returned as timestamps. This is a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aws/amazon-cognito-identity-js/473)
<!-- Reviewable:end -->
