### PR TITLE
Adjust time with clock drift when validating session

### DIFF
--- a/src/CognitoAccessToken.js
+++ b/src/CognitoAccessToken.js
@@ -15,32 +15,15 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/global';
+import CognitoJwtToken from './CognitoJwtToken';
 
 /** @class */
-export default class CognitoAccessToken {
+export default class CognitoAccessToken extends CognitoJwtToken {
   /**
    * Constructs a new CognitoAccessToken object
    * @param {string=} AccessToken The JWT access token.
    */
   constructor({ AccessToken } = {}) {
-    // Assign object
-    this.jwtToken = AccessToken || '';
-  }
-
-  /**
-   * @returns {string} the record's token.
-   */
-  getJwtToken() {
-    return this.jwtToken;
-  }
-
-  /**
-   * @returns {int} the token's expiration (exp member).
-   */
-  getExpiration() {
-    const payload = this.jwtToken.split('.')[1];
-    const expiration = JSON.parse(util.base64.decode(payload).toString('utf8'));
-    return expiration.exp;
+    super(AccessToken || '');
   }
 }

--- a/src/CognitoIdToken.js
+++ b/src/CognitoIdToken.js
@@ -15,32 +15,15 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/global';
+import CognitoJwtToken from './CognitoJwtToken';
 
 /** @class */
-export default class CognitoIdToken {
+export default class CognitoIdToken extends CognitoJwtToken {
   /**
    * Constructs a new CognitoIdToken object
    * @param {string=} IdToken The JWT Id token
    */
   constructor({ IdToken } = {}) {
-    // Assign object
-    this.jwtToken = IdToken || '';
-  }
-
-  /**
-   * @returns {string} the record's token.
-   */
-  getJwtToken() {
-    return this.jwtToken;
-  }
-
-  /**
-   * @returns {int} the token's expiration (exp member).
-   */
-  getExpiration() {
-    const payload = this.jwtToken.split('.')[1];
-    const expiration = JSON.parse(util.base64.decode(payload).toString('utf8'));
-    return expiration.exp;
+    super(IdToken || '');
   }
 }

--- a/src/CognitoJwtToken.js
+++ b/src/CognitoJwtToken.js
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2016 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the
+ * License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, express or implied. See the License
+ * for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { util } from 'aws-sdk/global';
+
+/** @class */
+export default class CognitoJwtToken {
+  /**
+   * Constructs a new CognitoJwtToken object
+   * @param {string=} token The JWT token.
+   */
+  constructor(token) {
+    // Assign object
+    this.jwtToken = token || '';
+    this.payload = this.decodePayload();
+  }
+
+  /**
+   * @returns {string} the record's token.
+   */
+  getJwtToken() {
+    return this.jwtToken;
+  }
+
+  /**
+   * @returns {int} the token's expiration (exp member).
+   */
+  getExpiration() {
+    return this.payload.exp;
+  }
+
+  /**
+   * @returns {int} the token's "issued at" (iat member).
+   */
+  getIssuedAt() {
+    return this.payload.iat;
+  }
+
+  /**
+   * @returns {object} the token's payload.
+   */
+  decodePayload() {
+    const payload = this.jwtToken.split('.')[1];
+    try {
+      return JSON.parse(util.base64.decode(payload).toString('utf8'));
+    } catch (err) {
+      return {};
+    }
+  }
+}

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -885,7 +885,7 @@ export default class CognitoUser {
       const refreshToken = new CognitoRefreshToken({
         RefreshToken: this.storage.getItem(refreshTokenKey),
       });
-      const clockDrift = this.storage.getItem(clockDriftKey) || 0;
+      const clockDrift = parseInt(this.storage.getItem(clockDriftKey), 0) || 0;
 
       const sessionData = {
         IdToken: idToken,

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -873,6 +873,7 @@ export default class CognitoUser {
     const idTokenKey = `${keyPrefix}.idToken`;
     const accessTokenKey = `${keyPrefix}.accessToken`;
     const refreshTokenKey = `${keyPrefix}.refreshToken`;
+    const clockDriftKey = `${keyPrefix}.clockDrift`;
 
     if (this.storage.getItem(idTokenKey)) {
       const idToken = new CognitoIdToken({
@@ -884,11 +885,13 @@ export default class CognitoUser {
       const refreshToken = new CognitoRefreshToken({
         RefreshToken: this.storage.getItem(refreshTokenKey),
       });
+      const clockDrift = this.storage.getItem(clockDriftKey) || 0;
 
       const sessionData = {
         IdToken: idToken,
         AccessToken: accessToken,
         RefreshToken: refreshToken,
+        ClockDrift: clockDrift,
       };
       const cachedSession = new CognitoUserSession(sessionData);
       if (cachedSession.isValid()) {
@@ -961,11 +964,13 @@ export default class CognitoUser {
     const idTokenKey = `${keyPrefix}.${this.username}.idToken`;
     const accessTokenKey = `${keyPrefix}.${this.username}.accessToken`;
     const refreshTokenKey = `${keyPrefix}.${this.username}.refreshToken`;
+    const clockDriftKey = `${keyPrefix}.${this.username}.clockDrift`;
     const lastUserKey = `${keyPrefix}.LastAuthUser`;
 
     this.storage.setItem(idTokenKey, this.signInUserSession.getIdToken().getJwtToken());
     this.storage.setItem(accessTokenKey, this.signInUserSession.getAccessToken().getJwtToken());
     this.storage.setItem(refreshTokenKey, this.signInUserSession.getRefreshToken().getToken());
+    this.storage.setItem(clockDriftKey, this.signInUserSession.getClockDrift());
     this.storage.setItem(lastUserKey, this.username);
   }
 

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -42,7 +42,11 @@ export default class CognitoUserPool {
     this.userPoolId = UserPoolId;
     this.clientId = ClientId;
 
-    this.client = new CognitoIdentityServiceProvider({ apiVersion: '2016-04-19', region, endpoint });
+    this.client = new CognitoIdentityServiceProvider({
+      apiVersion: '2016-04-19',
+      region,
+      endpoint,
+    });
 
     this.storage = data.Storage || new StorageHelper().getStorage();
   }

--- a/src/CognitoUserSession.js
+++ b/src/CognitoUserSession.js
@@ -22,8 +22,9 @@ export default class CognitoUserSession {
    * @param {string} IdToken The session's Id token.
    * @param {string=} RefreshToken The session's refresh token.
    * @param {string} AccessToken The session's access token.
+   * @param {int} ClockDrift The saved computer's clock drift or undefined to force calculation.
    */
-  constructor({ IdToken, RefreshToken, AccessToken } = {}) {
+  constructor({ IdToken, RefreshToken, AccessToken, ClockDrift } = {}) {
     if (AccessToken == null || IdToken == null) {
       throw new Error('Id token and Access Token must be present.');
     }
@@ -31,6 +32,7 @@ export default class CognitoUserSession {
     this.idToken = IdToken;
     this.refreshToken = RefreshToken;
     this.accessToken = AccessToken;
+    this.clockDrift = ClockDrift === undefined ? this.calculateClockDrift() : ClockDrift;
   }
 
   /**
@@ -55,13 +57,31 @@ export default class CognitoUserSession {
   }
 
   /**
+   * @returns {int} the session's clock drift
+   */
+  getClockDrift() {
+    return this.clockDrift;
+  }
+
+  /**
+   * @returns {int} the computer's clock drift
+   */
+  calculateClockDrift() {
+    const now = Math.floor(new Date() / 1000);
+    const iat = Math.min(this.accessToken.getIssuedAt(), this.idToken.getIssuedAt());
+
+    return now - iat;
+  }
+
+  /**
    * Checks to see if the session is still valid based on session expiry information found
-   * in tokens and the current time
+   * in tokens and the current time (adjusted with clock drift)
    * @returns {boolean} if the session is still valid
    */
   isValid() {
     const now = Math.floor(new Date() / 1000);
+    const adjusted = now - this.clockDrift;
 
-    return now < this.accessToken.getExpiration() && now < this.idToken.getExpiration();
+    return adjusted < this.accessToken.getExpiration() && adjusted < this.idToken.getExpiration();
   }
 }


### PR DESCRIPTION
This PR improves the session validation using the computer's clock drift.

It works as follows:
* After authentication, the computer's clock is compared with the JWT `iat` claim. The difference is saved in the storage.
* When validating the session, the current time is adjusted with the saved clock drift.

(this assumes a constant clock drift between authentications)

I implemented this because we had the case of a user with his computer clock more than 1 hour off in the future (positive drift), the session was never valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aws/amazon-cognito-identity-js/541)
<!-- Reviewable:end -->
