### PR TITLE
Move msCrypto check to index.js

### DIFF
--- a/enhance.js
+++ b/enhance.js
@@ -6,10 +6,3 @@ export * from './src';
 Object.keys(enhancements).forEach(key => {
   CognitoIdentityServiceProvider[key] = enhancements[key];
 });
-
-// The version of crypto-browserify included by aws-sdk only
-// checks for window.crypto, not window.msCrypto as used by
-// IE 11 – so we set it explicitly here
-if (typeof window !== 'undefined' && !window.crypto && window.msCrypto) {
-  window.crypto = window.msCrypto;
-}

--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,10 @@ export { default as CognitoUserAttribute } from './CognitoUserAttribute';
 export { default as CognitoUserPool } from './CognitoUserPool';
 export { default as CognitoUserSession } from './CognitoUserSession';
 export { default as DateHelper } from './DateHelper';
+
+// The version of crypto-browserify included by aws-sdk only
+// checks for window.crypto, not window.msCrypto as used by
+// IE 11 – so we set it explicitly here
+if (typeof window !== 'undefined' && !window.crypto && window.msCrypto) {
+  window.crypto = window.msCrypto;
+}


### PR DESCRIPTION
Moved `msCyrpto` check from `enhance.js` to `index.js` so that it is also included in the ES build (otherwise it's only included in the `dist` files via webpack).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aws/amazon-cognito-identity-js/562)
<!-- Reviewable:end -->
