### PR TITLE
Add missing argument declaration in type file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ declare module "amazon-cognito-identity-js" {
     export class CognitoUser {
         constructor(data: ICognitoUserData);
 
-        public setSignInUserSession(CognitoUserSession): void;
+        public setSignInUserSession(signInUserSession: CognitoUserSession): void;
         public getSignInUserSession(): CognitoUserSession | null;
         public getUsername(): string;
 


### PR DESCRIPTION
1.23 breaks TS builds due to a missing argument declaration.