### PR TITLE
Fix type conversion issue with clockDrift store fixes #588

### DIFF
--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -1033,7 +1033,7 @@ export default class CognitoUser {
     this.storage.setItem(idTokenKey, this.signInUserSession.getIdToken().getJwtToken());
     this.storage.setItem(accessTokenKey, this.signInUserSession.getAccessToken().getJwtToken());
     this.storage.setItem(refreshTokenKey, this.signInUserSession.getRefreshToken().getToken());
-    this.storage.setItem(clockDriftKey, this.signInUserSession.getClockDrift());
+    this.storage.setItem(clockDriftKey, `${this.signInUserSession.getClockDrift()}`);
     this.storage.setItem(lastUserKey, this.username);
   }
 


### PR DESCRIPTION
Clock drift feature was added in previous commits, but the store did not explicitly convert to string when storing the variable. Adding the explicit conversion fixes the issue.