### PR TITLE
Enable session cookies

### DIFF
--- a/src/CookieStorage.js
+++ b/src/CookieStorage.js
@@ -19,7 +19,7 @@ export default class CookieStorage {
     } else {
       this.path = '/';
     }
-    if (data.expire){
+    if (data.hasOwnProperty('expires')){
       this.expires = data.expires;
     } else {
       this.expires = 365;


### PR DESCRIPTION
To set session scoped cookies, one must set the expires parameter to 0. Using hasOwnProperty method allows to overcome the limit of the if statement. Moreover, the current implementation seems to have a tipo, as the check is performed on "expire" and the value is taken from "expire**s**" and the jsdoc advocates "expires".