### PR TITLE
Adds a podspec for CocoaPods support

### DIFF
--- a/RNAWSCognito.podspec
+++ b/RNAWSCognito.podspec
@@ -1,0 +1,19 @@
+# coding: utf-8
+Pod::Spec.new do |s|
+  s.name    = "RNAWSCognito"
+  s.version = "1.29.0"
+  s.requires_arc = true
+  s.platforms = { :ios => "8.0" }
+  s.license = { :file => 'LICENSE.txt' }
+  s.homepage = "https://github.com/aws/amazon-cognito-identity-js"
+  s.author = "Amazon"
+  
+  s.summary = "Amazon Cognito Identity SDK for JavaScript"
+  s.description = <<-DESC
+                    The Amazon Cognito Identity SDK for JavaScript allows JavaScript enabled applications to sign-up users, authenticate users, view, delete, and update user attributes within the Amazon Cognito Identity service.
+                  DESC
+
+  s.source = { :git => "https://github.com/aws/amazon-cognito-identity-js.git", :tag => s.version.to_s }
+  s.source_files     = 'ios/RNAWSCognito.{h,m}'
+  s.dependency 'JKBigInteger2', '0.0.5'
+end


### PR DESCRIPTION
## Motivation

`react-native link` now [supports CocoaPods projects](https://github.com/facebook/react-native/pull/15460). If somebody wants to use the existing `react-native link` instructions to add Cognito to their CocoaPods-enabled project, it needs a podspec to link properly. This PR adds that podspec.

As a nice side effect, it also removes the need for those projects to depend on [vendored](https://github.com/aws/amazon-cognito-identity-js/tree/master/ios/JKBigInteger) `JKBigInteger` code, since it just expresses that library as a CocoaPods dependency.

## How to test

Follow the [Install for React Native](https://github.com/aws/amazon-cognito-identity-js#install-for-react-native) instructions from this repo's README on an iOS project that uses CocoaPods. You'll need to use a copy of the JS that includes this change. You can also install manually by adding `RNAWSCognito` to the project's `Podfile`.