### PR TITLE
Add and update MFA typescript interface for CognitoUser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ios/RNAWSCognito.project.xcworkspace/xcuserdata/
 ios/RNAWSCognito.xcodeproj/project.xcworkspace/xcuserdata/
 
 .DS_Store
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,10 @@ declare module "amazon-cognito-identity-js" {
                                     onFailure: (err: any) => void,
                                     newPasswordRequired?: (userAttributes: any, requiredAttributes: any) => void,
                                     mfaRequired?: (challengeName: any, challengeParameters: any) => void,
-                                    customChallenge?: (challengeParameters: any) => void
+                                    totpRequired?: (challengeName: any, challengeParameters: any) => void,
+                                    customChallenge?: (challengeName: any, challengeParameters: any) => void,
+                                    mfaSetup?: (challengeName: any, challengeParameters: any) => void,
+                                    selectMFAType?: (challengeName: any, challengeParameters: any) => void
                                 }): void;
         public confirmRegistration(code: string, forceAliasCreation: boolean, callback: NodeCallback<any, any>): void;
         public sendCustomChallengeAnswer(answerChallenge: any, callback:NodeCallback<any, any>):void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ declare module "amazon-cognito-identity-js" {
         public setDeviceStatusRemembered(callbacks: { onSuccess: (success: string) => void, onFailure: (err: any) => void }): void;
         public setDeviceStatusNotRemembered(callbacks: { onSuccess: (success: string) => void, onFailure: (err: any) => void }): void;
         public getDevice(callbacks: {onSuccess: (success: string) => void, onFailure: (err: Error) => void}): any;
-        public sendMFACode(confirmationCode: string, callbacks: { onSuccess: (session: CognitoUserSession) => void, onFailure: (err: any) => void }): void;
+        public sendMFACode(confirmationCode: string, callbacks: { onSuccess: (session: CognitoUserSession) => void, onFailure: (err: any) => void }, mfaType: string): void;
         public completeNewPasswordChallenge(newPassword: string,
                                             requiredAttributeData: any,
                                             callbacks: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,7 @@ declare module "amazon-cognito-identity-js" {
             associateSecretCode: (secretCode: string) => void,
             onFailure: (err: any) => void
         });
+        public verifySoftwareToken(totpCode, friendlyDeviceName, callbacks: {onSuccess: (session: CognitoUserSession) => void, onFailure: (err: Error) => void}): any;
     }
 
     export interface MFAOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,10 @@ declare module "amazon-cognito-identity-js" {
         public enableMFA(callback: NodeCallback<Error, string>): void;
         public disableMFA(callback: NodeCallback<Error, string>): void;
         public getMFAOptions(callback: NodeCallback<Error, MFAOption[]>): void;
+        public associateSoftwareToken(callbacks: {
+            associateSecretCode: (secretCode: string) => void,
+            onFailure: (err: any) => void
+        });
     }
 
     export interface MFAOption {


### PR DESCRIPTION
There are some missing and inconsistent typescript interfaces for Cognito that cause compiler warnings when using in TypeScript projects. This will add those interfaces. Solution has been tested and implemented. Please let me know if you have any questions or changes you would like me to make. 

On another note there are some interface methods which I don't understand and seem to be inconsistent with the other interfaces like associateSoftwareToken. Also it seems that challengeParameters is not JSON deserialized. If you like I could clean them up so that they are compatible with the rest of the library. Let me know. 