### PR TITLE
Adds missing 'listDevices' function to CognitoUser class for TypeScript type safety

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ declare module "amazon-cognito-identity-js" {
         public setDeviceStatusRemembered(callbacks: { onSuccess: (success: string) => void, onFailure: (err: any) => void }): void;
         public setDeviceStatusNotRemembered(callbacks: { onSuccess: (success: string) => void, onFailure: (err: any) => void }): void;
         public getDevice(callbacks: {onSuccess: (success: string) => void, onFailure: (err: Error) => void}): any;
+        public listDevices(limit: number, paginationToken: string, callbacks: {onSuccess: (data: any) => void, onFailure: (err: Error) => void}): void;
         public sendMFACode(confirmationCode: string, callbacks: { onSuccess: (session: CognitoUserSession) => void, onFailure: (err: any) => void }): void;
         public completeNewPasswordChallenge(newPassword: string,
                                             requiredAttributeData: any,


### PR DESCRIPTION
This function is missing from the CognitoUser class in index.d.ts which causes issues trying to use it in TS projects.

I've also done this in the [Amplify repository](https://github.com/aws/aws-amplify/pull/276).